### PR TITLE
ON-4029 | csd | Modify to check validation prior to publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-kiln",
-  "version": "9.0.0+2",
+  "version": "9.0.0+3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-kiln",
-  "version": "9.0.0+2",
+  "version": "9.0.0+3",
   "description": "Editor tools for Clay",
   "template": "template.handlebars",
   "scripts": {


### PR DESCRIPTION
This adds a pre-publish validation check for validations that check against changes that have happened outside of the current article prior to publish. 

- Additional note: this also adds a directive to complete the publishing action after publishing finishes, regardless of error. This should fix the issue that occasionally comes up when there is an error during publishing and the publish button is no longer available until the page is refreshed.