### PR TITLE
ON-4070 | Page meta data not editable

### DIFF
--- a/lib/drawers/head-components.vue
+++ b/lib/drawers/head-components.vue
@@ -72,8 +72,7 @@
       openSettings(id) {
         const path = 'settings';
 
-        // If a different element is selected, the overlay form will use the
-        // wrong schema resulting in disabled fields, so unselect first.
+        // Unselect to prevent the overlay form from using the wrong component's schema
         this.$store.dispatch('unselect');
         this.$store.dispatch('focus', { uri: id, path });
       },

--- a/lib/drawers/head-components.vue
+++ b/lib/drawers/head-components.vue
@@ -72,6 +72,9 @@
       openSettings(id) {
         const path = 'settings';
 
+        // If a different element is selected, the overlay form will use the
+        // wrong schema resulting in disabled fields, so unselect first.
+        this.$store.dispatch('unselect');
         this.$store.dispatch('focus', { uri: id, path });
       },
       removeComponent(id) {

--- a/lib/drawers/invisible-components.vue
+++ b/lib/drawers/invisible-components.vue
@@ -65,8 +65,7 @@
       openSettings(id) {
         const path = 'settings';
 
-        // If a different element is selected, the overlay form will use the
-        // wrong schema resulting in disabled fields, so unselect first.
+        // Unselect to prevent the overlay form from using the wrong component's schema
         this.$store.dispatch('unselect');
         this.$store.dispatch('focus', { uri: id, path });
       },

--- a/lib/drawers/invisible-components.vue
+++ b/lib/drawers/invisible-components.vue
@@ -65,6 +65,9 @@
       openSettings(id) {
         const path = 'settings';
 
+        // If a different element is selected, the overlay form will use the
+        // wrong schema resulting in disabled fields, so unselect first.
+        this.$store.dispatch('unselect');
         this.$store.dispatch('focus', { uri: id, path });
       },
       removeComponent(id) {


### PR DESCRIPTION
If another component is selected when a head/invisible component settings form is opened, the form will use that other component's schema for some field data.  This will cause the head component fields to be disabled if fields by the same name do not exist in the other component.  The fix here is to dispatch an unselect action when opening the form.